### PR TITLE
Inline and restyle setup page in Code.gs

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -25,6 +25,318 @@ function getShortcuts() {
 }
 
 
+function getSettings() {
+  const scriptProps = PropertiesService.getScriptProperties();
+  const userProps = PropertiesService.getUserProperties();
+
+  return {
+    owner: scriptProps.getProperty("GITHUB_OWNER") || "",
+    repo: scriptProps.getProperty("GITHUB_REPO") || "",
+    folder: scriptProps.getProperty("GITHUB_FOLDER") || "",
+    token: userProps.getProperty("GITHUB_TOKEN") || ""
+  };
+}
+
+
+function saveSettings(form) {
+  const scriptProps = PropertiesService.getScriptProperties();
+  const userProps = PropertiesService.getUserProperties();
+
+  const settings = {
+    owner: (form.owner || "").trim(),
+    repo: (form.repo || "").trim(),
+    folder: (form.folder || "").trim(),
+    token: (form.token || "").trim()
+  };
+
+  scriptProps.setProperties(
+    {
+      GITHUB_OWNER: settings.owner,
+      GITHUB_REPO: settings.repo,
+      GITHUB_FOLDER: settings.folder
+    },
+    true
+  );
+
+  if (settings.token) {
+    userProps.setProperty("GITHUB_TOKEN", settings.token);
+  } else {
+    userProps.deleteProperty("GITHUB_TOKEN");
+  }
+
+  return getSettings();
+}
+
+
+function escapeHtml(value) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+
+function renderSetupPage(settings) {
+  return `<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Shortcut Sync Setup</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --primary: #1a73e8;
+        --primary-dark: #0b57d0;
+        --surface: #ffffff;
+        --muted: #5f6368;
+        --danger: #a50e0e;
+        --success: #0b5a2a;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 40px 16px;
+        font-family: 'Google Sans', Roboto, 'Segoe UI', sans-serif;
+        background: linear-gradient(135deg, #e8f0fe 0%, #f8fbff 45%, #f3f7ff 100%);
+        color: #202124;
+      }
+      .shell {
+        width: 100%;
+        max-width: 520px;
+        background: var(--surface);
+        border-radius: 18px;
+        box-shadow: 0 20px 45px rgba(26, 115, 232, 0.16);
+        padding: 36px 42px;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+      }
+      header .icon {
+        width: 52px;
+        height: 52px;
+        border-radius: 16px;
+        background: rgba(26, 115, 232, 0.12);
+        display: grid;
+        place-items: center;
+        font-size: 26px;
+        color: var(--primary);
+      }
+      header h1 {
+        margin: 0;
+        font-size: 24px;
+        font-weight: 600;
+      }
+      header p {
+        margin: 4px 0 0;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      form {
+        margin-top: 28px;
+        display: grid;
+        gap: 20px;
+      }
+      label {
+        display: grid;
+        gap: 8px;
+      }
+      label span {
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
+        font-weight: 600;
+      }
+      input[type="text"],
+      input[type="password"] {
+        padding: 12px 14px;
+        font-size: 15px;
+        border-radius: 10px;
+        border: 1px solid rgba(32, 33, 36, 0.16);
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+      input[type="text"]:focus,
+      input[type="password"]:focus {
+        outline: none;
+        border-color: var(--primary);
+        box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.12);
+      }
+      .hint {
+        margin: 2px 0 0;
+        font-size: 12px;
+        color: var(--muted);
+      }
+      button {
+        justify-self: start;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        border: none;
+        border-radius: 999px;
+        padding: 12px 22px;
+        font-size: 15px;
+        font-weight: 600;
+        color: #fff;
+        background: linear-gradient(135deg, var(--primary), var(--primary-dark));
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease;
+      }
+      button:hover:not(:disabled) {
+        transform: translateY(-1px);
+        box-shadow: 0 10px 25px rgba(26, 115, 232, 0.28);
+      }
+      button:disabled {
+        opacity: 0.7;
+        cursor: default;
+        box-shadow: none;
+      }
+      button .loading {
+        display: none;
+      }
+      button.is-loading .label {
+        display: none;
+      }
+      button.is-loading .loading {
+        display: inline;
+      }
+      .status {
+        display: none;
+        margin-top: 28px;
+        padding: 12px 16px;
+        border-radius: 12px;
+        font-size: 14px;
+        line-height: 1.4;
+      }
+      .status.show {
+        display: block;
+      }
+      .status.info {
+        background: rgba(26, 115, 232, 0.12);
+        color: var(--primary-dark);
+      }
+      .status.success {
+        background: #e6f4ea;
+        color: var(--success);
+      }
+      .status.error {
+        background: #fce8e6;
+        color: var(--danger);
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <header>
+        <div class="icon">⚙️</div>
+        <div>
+          <h1>Shortcut Sync Setup</h1>
+          <p>Connect to your GitHub repo so new shortcuts land exactly where you need them.</p>
+        </div>
+      </header>
+      <form id="setup-form">
+        <label>
+          <span>GitHub owner</span>
+          <input type="text" name="owner" value="${escapeHtml(settings.owner)}" placeholder="octocat" required />
+        </label>
+        <label>
+          <span>Repository</span>
+          <input type="text" name="repo" value="${escapeHtml(settings.repo)}" placeholder="shortcuts" required />
+        </label>
+        <label>
+          <span>Repository folder</span>
+          <input type="text" name="folder" value="${escapeHtml(settings.folder)}" placeholder="scVersions" required />
+          <p class="hint">The folder will be created if it doesn't exist yet.</p>
+        </label>
+        <label>
+          <span>Personal access token</span>
+          <input type="password" name="token" value="${escapeHtml(settings.token)}" placeholder="ghp_..." autocomplete="off" required />
+          <p class="hint">Stored securely inside your Apps Script user properties.</p>
+        </label>
+        <button type="submit" id="save-button">
+          <span class="label">Save settings</span>
+          <span class="loading">Saving…</span>
+        </button>
+      </form>
+      <div id="status" class="status info show" role="status" aria-live="polite">Ready to save your GitHub settings.</div>
+    </main>
+    <script>
+      const form = document.getElementById('setup-form');
+      const statusEl = document.getElementById('status');
+      const saveButton = document.getElementById('save-button');
+      const fieldNames = ['owner', 'repo', 'folder', 'token'];
+
+      function setStatus(message, kind) {
+        const classes = ['status', kind || 'info'];
+        if (message) {
+          classes.push('show');
+        }
+        statusEl.className = classes.join(' ');
+        statusEl.textContent = message || '';
+      }
+
+      function setLoading(isLoading) {
+        saveButton.disabled = isLoading;
+        saveButton.classList.toggle('is-loading', isLoading);
+      }
+
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        setStatus('Saving settings…', 'info');
+        setLoading(true);
+        const data = {};
+        fieldNames.forEach((field) => {
+          const input = form.elements.namedItem(field);
+          if (input) {
+            data[field] = input.value;
+          }
+        });
+
+        google.script.run
+          .withSuccessHandler((result) => {
+            setLoading(false);
+            setStatus('Settings saved successfully. You can close this window.', 'success');
+            if (result && typeof result === 'object') {
+              fieldNames.forEach((field) => {
+                const input = form.elements.namedItem(field);
+                if (input && field in result) {
+                  input.value = result[field] || '';
+                }
+              });
+            }
+          })
+          .withFailureHandler((error) => {
+            setLoading(false);
+            const message = error && error.message ? error.message : String(error || 'Unknown error');
+            setStatus('Failed to save settings: ' + message, 'error');
+          })
+          .saveSettings(data);
+      });
+    </script>
+  </body>
+</html>`;
+}
+
+
+function doGet() {
+  return HtmlService.createHtmlOutput(renderSetupPage(getSettings())).setTitle("Shortcut Sync Setup");
+}
+
+
 /**
  * Create a folder in a GitHub repo and upload shortcut files.
  *
@@ -35,6 +347,20 @@ function getShortcuts() {
  * @param {string} token - GitHub personal access token
  */
 function uploadShortcutsToGitHub(owner, repo, folder, ids, token) {
+  if (!owner) {
+    throw new Error("Missing GitHub owner. Please configure the setup page.");
+  }
+  if (!repo) {
+    throw new Error("Missing GitHub repo. Please configure the setup page.");
+  }
+  if (!token) {
+    throw new Error("Missing GitHub token. Please configure the setup page.");
+  }
+
+  const normalizedFolder = (folder || "")
+    .replace(/^[\s/]+/, "")
+    .replace(/[\s/]+$/, "");
+
   ids.forEach(function(id) {
     // 1. Fetch shortcut latest version
     const url = `https://rhapi.sm0ke.org/api/v1/shortcuts/${id}/versions/latest`;
@@ -45,7 +371,8 @@ function uploadShortcutsToGitHub(owner, repo, folder, ids, token) {
     const encoded = Utilities.base64Encode(content);
 
     // 3. Upload file to GitHub
-    const ghUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${folder}/${id}.txt`;
+    const ghPath = normalizedFolder ? `${normalizedFolder}/${id}.txt` : `${id}.txt`;
+    const ghUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${ghPath}`;
 
     const payload = {
       message: `Add shortcut ${id}`,
@@ -68,6 +395,32 @@ function uploadShortcutsToGitHub(owner, repo, folder, ids, token) {
 }
 
 
+function uploadShortcutsFromSettings() {
+  const settings = getSettings();
+  const ids = getShortcuts();
+
+  const missing = [];
+  if (!settings.owner) missing.push("GitHub owner");
+  if (!settings.repo) missing.push("GitHub repo");
+  if (!settings.folder) missing.push("GitHub folder");
+  if (!settings.token) missing.push("GitHub token");
+
+  if (missing.length) {
+    throw new Error(
+      "Missing required settings: " + missing.join(", ") + ". Please complete the setup page."
+    );
+  }
+
+  uploadShortcutsToGitHub(
+    settings.owner,
+    settings.repo,
+    settings.folder,
+    ids,
+    settings.token
+  );
+}
+
+
 function test() {
-  uploadShortcutsToGitHub("SmokeSlate", "Shortcuts","scVersions", getShortcuts(), "")
+  uploadShortcutsFromSettings();
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # updateCache
-Cache shortcut updates from routinehub.
+
+Cache shortcut updates from RoutineHub and push them to a GitHub repository.
+
+## Setup
+
+1. Open the Apps Script project and choose **Run > Test deployments > doGet** to launch the setup page, or deploy it as a web app.
+2. Use the form to provide:
+   - GitHub owner or organization name
+   - Repository name
+   - Folder path inside the repository where the shortcut files should be stored
+   - A GitHub personal access token with `repo` scope
+3. Save the form. The non-sensitive values are stored in Script Properties; the personal access token is stored in your User Properties.
+
+Once saved, you can run `test` (or `uploadShortcutsFromSettings`) to fetch the latest published shortcuts and upload them to your configured repository.


### PR DESCRIPTION
## Summary
- inline the Apps Script setup form HTML/CSS/JS directly in `Code.gs`
- refresh the form styling, loading indicator, and status messaging for a more polished setup experience
- escape stored property values before echoing them into the inline form markup

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c8a32a3b8c8330b0aba61fdcca37a4